### PR TITLE
Add slash to repo URL in README

### DIFF
--- a/{{cookiecutter.beat}}/README.md
+++ b/{{cookiecutter.beat}}/README.md
@@ -22,7 +22,7 @@ To push {{cookiecutter.beat|capitalize}} in the git repository, run the followin
 git init
 git add .
 git commit
-git remote set-url origin https://{{cookiecutter.beat_path}}{{cookiecutter.beat}}
+git remote set-url origin https://{{cookiecutter.beat_path}}/{{cookiecutter.beat}}
 git push origin master
 ```
 

--- a/{{cookiecutter.beat}}/beater/{{cookiecutter.beat}}.go
+++ b/{{cookiecutter.beat}}/beater/{{cookiecutter.beat}}.go
@@ -55,7 +55,7 @@ func (bt *{{cookiecutter.beat|capitalize}}) Setup(b *beat.Beat) error {
 }
 
 func (bt *{{cookiecutter.beat|capitalize}}) Run(b *beat.Beat) error {
-	logp.Info("demobeat is running! Hit CTRL-C to stop it.")
+	logp.Info("{{cookiecutter.beat}} is running! Hit CTRL-C to stop it.")
 
 	ticker := time.NewTicker(bt.period)
 	counter := 1


### PR DESCRIPTION
The generated URL was missing a slash between the username and the repo name.