### PR TITLE
Generate a cleaner git history

### DIFF
--- a/{{cookiecutter.beat}}/Makefile
+++ b/{{cookiecutter.beat}}/Makefile
@@ -14,7 +14,20 @@ init:
 	glide update  --no-recursive
 	make update
 	git init
+
+.PHONY: commit
+commit:
+	git add README.md CONTRIBUTING.md
+	git commit -m "Initial commit"
+	git add LICENSE
+	git commit -m "Add the LICENSE"
+	git add .gitignore .gitattributes
+	git commit -m "Add git settings"
 	git add .
+	git reset -- .travis.yml
+	git commit -m "Add {{cookiecutter.beat}}"
+	git add .travis.yml
+	git commit -m "Add Travis CI"
 
 .PHONY: update-deps
 update-deps:

--- a/{{cookiecutter.beat}}/README.md
+++ b/{{cookiecutter.beat}}/README.md
@@ -8,17 +8,23 @@ Ensure that this folder is at the following location:
 ## Getting Started with {{cookiecutter.beat|capitalize}}
 
 ### Init Project
-To get running with {{cookiecutter.beat|capitalize}}, run the following commands:
+To get running with {{cookiecutter.beat|capitalize}}, run the following command:
 
 ```
 make init
 ```
 
+To commit the first version before you modify it, run:
+
+```
+make commit
+```
+
+It will create a clean git history for each major step. Note that you can always rewrite the history if you wish before pushing your changes.
 
 To push {{cookiecutter.beat|capitalize}} in the git repository, run the following commands:
 
 ```
-git commit 
 git remote set-url origin https://{{cookiecutter.beat_path}}/{{cookiecutter.beat}}
 git push origin master
 ```
@@ -46,7 +52,7 @@ To run {{cookiecutter.beat|capitalize}} with debugging output enabled, run:
 
 ### Test
 
-To test {{cookiecutter.beat|capitalize}}, run the following commands:
+To test {{cookiecutter.beat|capitalize}}, run the following command:
 
 ```
 make testsuite


### PR DESCRIPTION
By default all files are marked to be commited which means that the git
history by default would have one single commit with all the files.
It's often adviced to add a single README file as the first commit so in
case it's needed, you can always rewrite the history (only the first
commit can not be rewritten).

This commit generates a git log like this one:

```
3f9ae6d ‣ Add travis CI [3 hours ago by David Pilato]
0a22903 ‣ Add soundbeat [3 hours ago by David Pilato]
7483ed0 ‣ Add git settings [3 hours ago by David Pilato]
7b908eb ‣ Add the LICENSE [3 hours ago by David Pilato]
24c73bc ‣ Initial commit [3 hours ago by David Pilato]
```

Last is the oldest commit.

Closes #24.