### PR TITLE
Remove /vendor from .gitignore

### DIFF
--- a/{{cookiecutter.beat}}/.gitignore
+++ b/{{cookiecutter.beat}}/.gitignore
@@ -1,5 +1,4 @@
 /.idea
-/vendor
 /build
 
 .DS_Store

--- a/{{cookiecutter.beat}}/Makefile
+++ b/{{cookiecutter.beat}}/Makefile
@@ -31,7 +31,7 @@ commit:
 
 .PHONY: update-deps
 update-deps:
-	glide update  --no-recursive
+	glide update --no-recursive --strip-vcs
 
 # This is called by the beats packer before building starts
 .PHONY: before-build


### PR DESCRIPTION
Also add the `--strip-vcs` option to `glide update` so the user
doesn't have to manually delete the `.git` folders.